### PR TITLE
Bug fixed: Close socket in pc_transport_t when connection fails.

### DIFF
--- a/include/pomelo.h
+++ b/include/pomelo.h
@@ -88,6 +88,7 @@ typedef enum {
  */
 typedef enum {
   PC_TP_ST_INITED = 1,
+  PC_TP_ST_CONNECTING,
   PC_TP_ST_WORKING,
   PC_TP_ST_CLOSED
 } pc_transport_state;

--- a/src/network.c
+++ b/src/network.c
@@ -125,6 +125,7 @@ int pc_connect(pc_client_t *client, pc_connect_t *req,
     fprintf(stderr, "Fail to connect to server.");
     goto error;
   }
+  transport->state = PC_TP_ST_CONNECTING;
 
   return 0;
 


### PR DESCRIPTION
I found another bug in libpomelo, described as follows: 
As I tested reconnecting to server(the server is off-line on purpose. or there is no such server to connect. ) dozens of times, the programs stopped and warned 'libuv24, can not create kqueue'. After googling I doubt if there are sockets which are not closed properly.

As viewed under linux, there are indeed sockets unclosed after failing connecting to server. 
There is another state for pc_transport_t: PC_TP_ST_CONNECTING, which is missing from the declared states. 

When connection callback is made, the "pc_transport_destroy" can recognize this state and close the socket properly. 
