### PR TITLE
Add User Data

### DIFF
--- a/include/pomelo.h
+++ b/include/pomelo.h
@@ -31,6 +31,7 @@ extern "C" {
 
 #define PC_EVENT_DISCONNECT "disconnect"
 #define PC_EVENT_KICK "onKick"
+#define USER_DATA_COUNT 5
 
 typedef struct pc_client_s pc_client_t;
 typedef struct pc_listener_s pc_listener_t;
@@ -262,6 +263,9 @@ struct pc_client_s {
   uv_cond_t cond;
   uv_mutex_t listener_mutex;
   uv_thread_t worker;
+    
+  /* customized user data, used in callback */
+  void* userData[USER_DATA_COUNT];
 };
 
 /**
@@ -470,6 +474,38 @@ void pc_remove_listener(pc_client_t *client, const char *event,
  */
 void pc_emit_event(pc_client_t *client, const char *event, void *data);
 
+
+/**
+ * set customized user data, can be used in callback (especially in C++)
+ *
+ * @param client client instance.
+ * @param slot   which slot this user data goes in.
+ * @param data   user data set by user.
+ *
+ */
+void pc_set_user_data(pc_client_t *client, unsigned int slot, void *data);
+  
+/**
+ * get customized user data, can be used in callback (especially in C++)
+ *
+ * @param client client instance.
+ * @param slot   which slot this user data goes in.
+ *
+ */
+void* pc_get_user_data(pc_client_t *client, unsigned int slot);
+    
+    
+/**
+ * get client instance from request instance.
+ *
+ * @param req request instance.
+ *
+ *
+ */
+pc_client_t* pc_get_client(pc_request_t* req);
+    
+    
+    
 /* Don't export the private CPP symbols. */
 #undef PC_TCP_REQ_FIELDS
 #undef PC_REQ_FIELDS

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,57 @@
+//
+//  pomelo
+//  util.c
+//  
+//
+//  
+//
+//
+
+#include <stdio.h>
+#include "pomelo.h"
+
+/**
+ * set customized user data, can be used in callback (especially in C++)
+ *
+ * @param client client instance.
+ * @param slot   which slot this user data goes in.
+ * @param data   user data set by user.
+ *
+ */
+void pc_set_user_data(pc_client_t *client, unsigned int slot, void *data)
+{
+    if (slot >= USER_DATA_COUNT) {
+        return;
+    }
+    
+    client->userData[slot] = data;
+}
+
+
+/**
+ * get customized user data, can be used in callback (especially in C++)
+ *
+ * @param client client instance.
+ * @param slot   which slot this user data goes in.
+ *
+ */
+void* pc_get_user_data(pc_client_t *client, unsigned int slot)
+{
+    if (slot >= USER_DATA_COUNT) {
+        return NULL;
+    }
+    return client->userData[slot];
+}
+
+
+
+/**
+ * get client instance from request instance.
+ *
+ * @param req request instance.
+ *
+ */
+pc_client_t* pc_get_client(pc_request_t* req)
+{
+    return req->client;
+}


### PR DESCRIPTION
Since libpomelo uses callback between request and response, and in practice the callback will do in a separate thread context, user sometimes needs to save context information between callbacks. For example, in C++, a user can save this pointer into user defined data, during callback this pointer can be retrieved easily.

Below is some example code:

in request:  
    // register this object to pomelo client.
    pc_set_user_data(this->client, 0, (void*)this); 
    ...

in callback:
void on_request_cb(pc_request_t *req, int status, json_t *resp) {

```
pc_client_t * client = pc_get_client(req);
if (!client) {
    printf("[ERROR]: client is not available after request.\n");
    return;
}

void* userData = pc_get_user_data(client, 0);
WorkDescription* wd = (WorkDescription*)userData;
```

   ...
