### PR TITLE
fix protobuf decode repeated string

### DIFF
--- a/src/pb-decode.c
+++ b/src/pb-decode.c
@@ -310,6 +310,12 @@ static int checkreturn pb_decode_array(pb_istream_t *stream, const json_t *gprot
                 return 0;
             }
         }
+    } else if (pb__get_type(type_text) && pb__get_type(type_text) == PB_string) {
+        if (!pb_decode_proto(stream, gprotos, proto, protos, key, array)) {
+            if (need_decref)
+                json_decref(array);
+            return 0;
+        }
     } else {
         value = json_object();
         if (!pb_decode_proto(stream, gprotos, proto, protos, NULL, value)) {
@@ -321,6 +327,10 @@ static int checkreturn pb_decode_array(pb_istream_t *stream, const json_t *gprot
         json_array_append(array, value);
         json_decref(value);
     }
+
+#ifdef PB_DEBUG
+    printf("[PB_DEBUG:] decode array %s\n", json_dumps(array, 0));
+#endif
 
     json_object_set(result, key, array);
     if (need_decref)


### PR DESCRIPTION
when libpomelo decode "repeated string", it will decode as empty objects like [{},{},...].
the original code is
![bd78e1d4-e9c1-49a4-9e47-4ec73dcf7712](https://cloud.githubusercontent.com/assets/2226090/5261681/3a42b3cc-7a57-11e4-9dc7-dbabd054dacb.png)

seems like you intended to decode string as an object, but that do not conform to son format. so I wonder the why doing this ?

another possible fix is to modify pomelo-protobuf/lib/encoder.js, treat string as a simpleType and encoding its length, original code attached:
![0fb14364-9a66-4491-b0ff-d145756a39a9](https://cloud.githubusercontent.com/assets/2226090/5261749/2fb5d78a-7a58-11e4-9a05-d7e772fbcb2e.png)
